### PR TITLE
Use ternary operator instead of null coalese operator

### DIFF
--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -63,7 +63,7 @@ class Service extends Component
         /* @var Settings $settings */
         $settings = ImageResizer::$plugin->getSettings();
 
-        return $settings->assetSourceSettings[$sourceId][$setting] ?? $settings->$setting;
+        return $settings->assetSourceSettings[$sourceId][$setting] ?: $settings->$setting;
     }
 
     /**


### PR DESCRIPTION
I was noticing that I couldn't upload any files anymore since the 3.0.5 release because the $imageWidth and $imageHeight var returned an empty string. Looking into the getSettingForAssetSource function it seems like when using the coalese operator the first part is always true, even if empty (because it's always defined). The second part, the general settings are never reached. When using the ternary operator instead things seem to work correctly.